### PR TITLE
super-linter organization name update

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: github/super-linter/slim@v4
+      - uses: super-linter/super-linter/slim@v5
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main


### PR DESCRIPTION
### Describe your changes

super-linter changed the organization name from github to super-linter so we needed to update the references to this action from github/super-linter to super-linter/super-linter.