### PR TITLE
Bugfix - Update lost when updating two lines

### DIFF
--- a/scripts/auto-test-framework/readme_update.py
+++ b/scripts/auto-test-framework/readme_update.py
@@ -79,6 +79,7 @@ def main():
             value_to_add = inference_times[token]
             table = generate_table(value_to_add, token)
             rewrite_md_file(file_name, md_file, token, table)
+            md_file = read_md_file(file_name)
         else:
             print("Can't find token in file: " + token)
 


### PR DESCRIPTION
### Describe your changes

When the script edits multiple lines, the first line gets lost because the file was not reloaded before writing the second change.
Now it is fixed.
